### PR TITLE
Fix if no env

### DIFF
--- a/src/components/QuickStart.jsx
+++ b/src/components/QuickStart.jsx
@@ -1,6 +1,5 @@
 import { Card, Timeline, Typography } from "antd";
-import React, { useMemo } from "react";
-import { useMoralis } from "react-moralis";
+import React from "react";
 
 const { Text } = Typography;
 
@@ -23,10 +22,6 @@ const styles = {
 };
 
 export default function QuickStart({ isServerInfo }) {
-  const { Moralis } = useMoralis();
-
-  const isInchDex = useMemo(() => (Moralis.Plugins?.oneInch ? true : false), [Moralis.Plugins?.oneInch]);
-
   return (
     <div style={{ display: "flex", gap: "10px" }}>
       <Card
@@ -112,7 +107,7 @@ export default function QuickStart({ isServerInfo }) {
           </Timeline.Item>
 
           <Timeline.Item dot="💿">
-            <Text delete={isInchDex} style={styles.text}>
+            <Text style={styles.text}>
               Install{" "}
               <a
                 href="https://moralis.io/plugins/1inch/?utm_source=boilerplatehosted&utm_medium=todo&utm_campaign=ethereum-boilerplate"


### PR DESCRIPTION
If the `.env` file is not setup the `isServerInfo` is false [here](https://github.com/ethereum-boilerplate/ethereum-boilerplate/blob/d770064320d5f340ff89bf43cb60b1792550108d/src/index.js#L14) meaning we will **not** have MoralisProvider setup.

However, `QuickStart` page is using useMoralis() that results in the following error:
![moralisBug](https://user-images.githubusercontent.com/19240162/145271824-a89f4bbf-d6ec-4adc-84ee-cae5b410cc27.png)
 
This change removes the dependency from QuickStart. However, that meant not using `isInchDex` variable that was dependent on it.

It is probably ok quick fix but might need a better long-term fix.

@Y0moo could you please check this more, you have probably way better context than me on this one :) 