### PR TITLE
Add avalanche testnet to dropdown.

### DIFF
--- a/src/components/Chains/Chains.jsx
+++ b/src/components/Chains/Chains.jsx
@@ -76,6 +76,11 @@ const menuItems = [
     value: "Avalanche",
     icon: <AvaxLogo />,
   },
+  {
+    key: "0xa869",
+    value: "Avalanche Testnet",
+    icon: <AvaxLogo />,
+  },
 ];
 
 function Chains() {


### PR DESCRIPTION
Currently the dropdown doesn't support Fuji (the Avalanche testnet) despite having support for 4 Ethereum testnets and 1 Binance testnet.

This PR adds the Avalanche testnet to the dropdown.