### PR TITLE
resolve spelling error

### DIFF
--- a/src/components/QuickStart.jsx
+++ b/src/components/QuickStart.jsx
@@ -126,7 +126,7 @@ export default function QuickStart({ isServerInfo }) {
           </Timeline.Item>
 
           <Timeline.Item dot="🚀">
-            <Text style={styles.text}>BUIDL!!!</Text>
+            <Text style={styles.text}>BUILD!!!</Text>
           </Timeline.Item>
         </Timeline>
       </Card>


### PR DESCRIPTION
This PR is to simply fix the spelling error happening on the quick start page. I noticed your "about" section on this repo has it misspelled as well.
<img width="340" alt="Screen Shot 2021-12-24 at 11 48 42 PM" src="https://user-images.githubusercontent.com/16964213/147378359-59be71da-a511-4127-a367-337a8ffc6158.png">
