### PR TITLE
updated react scripts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-moralis": "^1.0.0",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
-    "react-scripts": "4.0.3",
+    "react-scripts": "5.0.0",
     "web-vitals": "^1.0.1",
     "yarn": "^1.22.17"
   },


### PR DESCRIPTION
`react-scripts` version `^4.0.3` has a dependency on `eslint` version `7.11.0`, so right now, when you try to run the repo as is, you run into a conflict since this repo right now depends on `eslint` version `^8.7.0`

I think we should also have a `yarn.lock` in this repo as well, to avoid this in the future. Any thoughts there? 