### PR TITLE
Remove ',' in index.jx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const Application = () => {
 
 ReactDOM.render(
   <StrictMode>
-    <Application />,
+    <Application />
   </StrictMode>,
   document.getElementById("root"),
 );


### PR DESCRIPTION
There is a front bug because of this ','

It is visible on the actual demo :
<img width="960" alt="image" src="https://user-images.githubusercontent.com/64586968/154648732-6a353d4c-9636-4576-ad2c-ac743d1d2106.png">

See the bot of the page