### PR TITLE
fix typo

### DIFF
--- a/src/components/QuickStart.jsx
+++ b/src/components/QuickStart.jsx
@@ -132,7 +132,7 @@ export default function QuickStart({ isServerInfo }) {
           </Timeline.Item>
 
           <Timeline.Item dot="🚀">
-            <Text style={styles.text}>BUIDL!!!</Text>
+            <Text style={styles.text}>BUILD!!!</Text>
           </Timeline.Item>
         </Timeline>
       </Card>


### PR DESCRIPTION
Fix typo on README - the first page each developer will encounter!
from `BUIDL` > `BUILD`