### PR TITLE
Typo in .env.local.example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,5 @@
 APP_CHAIN_ID=0x1
 APP_DOMAIN=ethereum.boilerplate 
 MORALIS_API_KEY= # Get your KEY https://admin.moralis.io/account/profile
-NEXTAUTH_SECRET= # Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/32
+NEXTAUTH_SECRET= # Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/64
 NEXTAUTH_URL=http://localhost:3000 # replace for production


### PR DESCRIPTION
32 bytes are 64 hexadecimal characters.