### PR TITLE
fix: NEXTAUTH_URL string quotes at .env file

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,4 +3,4 @@ MORALIS_API_KEY= ''
 # Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/64
 NEXTAUTH_SECRET= ''
 # replace for production
-NEXTAUTH_URL= http://localhost:3000
+NEXTAUTH_URL='http://localhost:3000'


### PR DESCRIPTION
NEXTAUTH_URL has to be inside quotes after #255 change.